### PR TITLE
add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/target
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM rust:1.67 as builder
+WORKDIR /usr/src/myapp
+COPY . .
+RUN cargo install --path .
+
+FROM debian:bullseye-slim
+COPY --from=builder /usr/local/cargo/bin/nostr-tool /usr/local/bin/nostr-tool
+CMD ["nostr-tool"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ cargo install nostr-tool
 cargo build --release
 ```
 
+### Build with Docker
+```shell
+docker build -t nostr-tool .
+```
+
 Run `nostr-tools` command once to get the standard help menu up. Each subcommand also has it's own help menu accessed by appending the --help flag.
 
 ## Examples
@@ -85,4 +90,9 @@ nostr-tool -r wss://nostr.oxtr.dev -p {PRIVATE_KEY} delete-event -e {EVENT_ID} -
 
 ```shell
 nostr-tool -r wss://nostr.oxtr.dev -p {PRIVATE_KEY} react -e {EVENT_ID} -a {EVENT_AUTHOR_PUBKEY} -r "👍"
+```
+
+### Run with docker
+```shell
+docker run nostr-tool nostr-tool -r wss://nostr.oxtr.dev text-note -c "Hello World"
 ```


### PR DESCRIPTION
I want to use this for something I'm working on but I don't want to install rust on my machine. This Dockerfile allows somebody to build the project with 
```docker build -t nostr-tool .```
 and run it with 
```docker run nostr-tool nostr-tool -r wss://nostr.oxtr.dev text-note -c "Hello World"```
 If you have a docker account you could publish the image so that anybody could run it without cloning the repo or installing rust with almost the same command.