### PR TITLE
adds ability to listen and print direct messages from a given pubkey

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,8 @@ enum Commands {
     PublishContactListCsv(sub_commands::publish_contactlist_csv::PublishContactListCsvSubCommand),
     /// Send a direct message
     SendDirectMessage(sub_commands::dm::SendDirectMessageSubCommand),
+    /// Read direct messages from relay
+    ReadDirectMessage(sub_commands::dm::ReadDirectMessageSubCommand),
     /// Delete an event
     DeleteEvent(sub_commands::delete_event::DeleteEventSubCommand),
     /// React to an event
@@ -109,6 +111,12 @@ fn main() -> Result<()> {
             args.relays,
             args.difficulty_target,
             sub_command_args,
+        ),
+        Commands::ReadDirectMessage(sub_command_args) => sub_commands::dm::read(
+            args.private_key,
+            args.relays,
+            args.difficulty_target,
+            sub_command_args
         ),
         Commands::DeleteEvent(sub_command_args) => sub_commands::delete_event::delete(
             args.private_key,

--- a/src/sub_commands/dm.rs
+++ b/src/sub_commands/dm.rs
@@ -50,3 +50,67 @@ pub fn send(
     }
     Ok(())
 }
+
+#[derive(Args)]
+pub struct ReadDirectMessageSubCommand {
+    /// Sender's public key. Both hex and bech32 encoded keys are supported.
+    #[arg(short, long)]
+    sender: String,
+    // Print keys as hex
+    #[arg(long, default_value = "false")]
+    hex: bool,
+}
+
+pub fn read(
+    private_key: Option<String>,
+    relays: Vec<String>,
+    difficulty_target: u8,
+    sub_command_args: &ReadDirectMessageSubCommand,
+) -> Result<()> {
+    if relays.is_empty() {
+        panic!("No relays specified, at least one relay is required!")
+    }
+
+    let keys = handle_keys(private_key, sub_command_args.hex)?;
+    let client = create_client(&keys, relays, difficulty_target)?;
+    let subscription = Filter::new()
+        .pubkey(keys.public_key())
+        .kind(Kind::EncryptedDirectMessage)
+        .since(Timestamp::now());
+
+    client.subscribe(vec![subscription]);
+
+    let hex_pubkey = parse_key(sub_command_args.sender.clone())?;
+    let sender = XOnlyPublicKey::from_str(&hex_pubkey)?;
+
+    client.handle_notifications(|notification| {
+        if let RelayPoolNotification::Event(_url, event) = notification {
+            if event.kind == Kind::EncryptedDirectMessage {
+                match decrypt(&keys.secret_key()?, &event.pubkey, &event.content) {
+                    Ok(msg) => {
+                        if !sub_command_args.hex {
+                            println!(
+                                "Message from {}, event id: {}, content: {}",
+                                sender.to_bech32()?,
+                                event.id.to_bech32()?,
+                                msg
+                            );
+                        } else {
+                            println!(
+                                "Message from {}, event id: {},  content: {}",
+                                sender,
+                                event.id.to_hex(), 
+                                msg
+                            );
+                        }
+                    }
+                    Err(e) => println!("Impossible to decrypt direct message: {e}"),
+                }
+            }
+        }
+        Ok(())
+    }).expect("error reading direct messages");
+
+    Ok(())
+
+}


### PR DESCRIPTION
I created this command to help myself with testing a nostr bot. 
Can be used like this:
```
./target/release/nostr-tool -r ws://localhost:8080 -p <private-key> read-direct-message --sender <public-key-of-sender>
```
Will block until a direct message is received (maybe a timeout would be a good idea?). 
```
Message from <public-key-of-sender>, event id: note1zntc7djw47h3a9me4pz46x0lmqq77hpepxy723rjvf9ckwkx53zshz7gc2, content: <de-encrypted dm>
```
If this doesn't seem useful to merge, no worries.