### PR TITLE
fix: `vanity` short `-h` conflict

### DIFF
--- a/src/sub_commands/vanity.rs
+++ b/src/sub_commands/vanity.rs
@@ -7,7 +7,7 @@ pub struct VanitySubCommand {
     #[arg(short, long, required = true, action = clap::ArgAction::Append)]
     prefixes: Vec<String>,
     /// Vanity pubkey in hex format
-    #[arg(short, long, default_value_t = false)]
+    #[arg(long, default_value_t = false)]
     hex: bool,
 }
 


### PR DESCRIPTION
Since help is -h hex needs t be long to avoid a conflict